### PR TITLE
feat: gerar pix e view criado

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,13 @@ Possíveis responses HTTP:
     { "mensagem": "Sincronize os estados antes de sincronizar cidades!" }
 ```
 OBS: em casos de erros ou autorização, segue o padrão descrito em [Erros](##Erros)
+### Gerar PIX
+Deve retornar um objeto com os detalhes da cobrança PIX
+
+Exemplo:
+``` json
+    {...}
+```
 ## Deleção
 O padrão de resposta para deleção será sempre uma mensagem no modelo a seguir
 

--- a/controllers/pixController.js
+++ b/controllers/pixController.js
@@ -40,7 +40,7 @@ const gerar = async (req, res) => {
 
         // PIX gerado com sucesso
         const novoPix = await PixModel.create({
-            valor: dadosPix.amount,
+            valor: (dadosPix.amount / 100),
             cod_copia_cola: dadosPix.brCode,
             qrcode_base64: dadosPix.brCodeBase64,
             id_beneficiario: req.beneficiario.id,
@@ -60,4 +60,32 @@ const gerar = async (req, res) => {
     }
 }
 
-export default { gerar };
+const selecionar = async (req, res) => {
+    try {
+        if(!req.params.id){
+            return res.status(400).json({ mensagem: `Informe o ID do PIX` });
+        }
+        const { id } = req.params;
+
+        // Verificar se ID é número
+        if(isNaN(id)){
+            return res.status(400).json({ mensagem: `ID do PIX inválido` });
+        }
+
+        const pix = await PixModel.findByPk(id);
+
+        if(!pix){
+            return res.status(404).json({ mensagem: `PIX não encontrado` });
+        }
+
+        return res.status(200).json(pix);
+
+    } catch (error) {
+        console.error(error);
+        return res.status(500).json({
+            mensagem: 'Erro interno, contate o suporte'
+        });
+    }
+};
+
+export default { gerar, selecionar };

--- a/controllers/pixController.js
+++ b/controllers/pixController.js
@@ -1,0 +1,63 @@
+// Importação de modelos
+import PixModel from '../models/pixModel.js';
+
+// Importação de Serviços
+import abacatePayService from '../services/abacatePayService.js';
+
+const gerar = async (req, res) => {
+    try {
+        const dadosObrigatorios = ['valor_decimal','cliente_nome','cliente_email','cliente_cpf_cnpj'];
+        const dados = req.body || {};
+        const dadosFaltantes = dadosObrigatorios.filter(dadoObrigatorio => !dados[dadoObrigatorio]);
+
+        if(dadosFaltantes.length > 0){
+            return res.status(400).json({
+                body: req.body,
+                detalhes: {
+                    obrigatorios: dadosObrigatorios
+                },
+                mensagem: `Dados obrigatórios não informados`
+            });
+        }
+
+        const pixResponse = await abacatePayService.gerarPix(dados);
+
+        // Erro literal
+        if(pixResponse.error){
+            throw new Error("Erro ao gerar PIX");
+        }
+
+        // Não é erro, mas não foi possível gerar PIX
+        if(!pixResponse.error && !pixResponse.ok){
+            return res.status(400).json({
+                body: req.body,
+                detalhes: {},
+                mensagem: pixResponse.mensagem
+            })
+        }
+
+        const dadosPix = pixResponse.data;
+
+        // PIX gerado com sucesso
+        const novoPix = await PixModel.create({
+            valor: dadosPix.amount,
+            cod_copia_cola: dadosPix.brCode,
+            qrcode_base64: dadosPix.brCodeBase64,
+            id_beneficiario: req.beneficiario.id,
+            id_integracao: dadosPix.id,
+            cliente_nome: dados.cliente_nome,
+            cliente_email: dados.cliente_email,
+            cliente_cpf_cnpj: dados.cliente_cpf_cnpj
+        });
+
+        return res.status(201).json(novoPix);
+
+    } catch (error) {
+        console.error(error);
+        return res.status(500).json({
+            mensagem: 'Erro interno, contate o suporte'
+        });
+    }
+}
+
+export default { gerar };

--- a/controllers/pixController.js
+++ b/controllers/pixController.js
@@ -1,4 +1,4 @@
-// Importação de modelos
+// Importação de Módulos
 import PixModel from '../models/pixModel.js';
 
 // Importação de Serviços
@@ -6,11 +6,11 @@ import abacatePayService from '../services/abacatePayService.js';
 
 const gerar = async (req, res) => {
     try {
-        const dadosObrigatorios = ['valor_decimal','cliente_nome','cliente_email','cliente_cpf_cnpj'];
+        const dadosObrigatorios = ['valor_decimal', 'cliente_nome', 'cliente_email', 'cliente_cpf_cnpj'];
         const dados = req.body || {};
         const dadosFaltantes = dadosObrigatorios.filter(dadoObrigatorio => !dados[dadoObrigatorio]);
 
-        if(dadosFaltantes.length > 0){
+        if (dadosFaltantes.length > 0) {
             return res.status(400).json({
                 body: req.body,
                 detalhes: {
@@ -23,12 +23,12 @@ const gerar = async (req, res) => {
         const pixResponse = await abacatePayService.gerarPix(dados);
 
         // Erro literal
-        if(pixResponse.error){
+        if (pixResponse.error) {
             throw new Error("Erro ao gerar PIX");
         }
 
         // Não é erro, mas não foi possível gerar PIX
-        if(!pixResponse.error && !pixResponse.ok){
+        if (!pixResponse.error && !pixResponse.ok) {
             return res.status(400).json({
                 body: req.body,
                 detalhes: {},
@@ -62,23 +62,51 @@ const gerar = async (req, res) => {
 
 const selecionar = async (req, res) => {
     try {
-        if(!req.params.id){
+        if (!req.params.id) {
             return res.status(400).json({ mensagem: `Informe o ID do PIX` });
         }
         const { id } = req.params;
 
         // Verificar se ID é número
-        if(isNaN(id)){
+        if (isNaN(id)) {
             return res.status(400).json({ mensagem: `ID do PIX inválido` });
         }
 
         const pix = await PixModel.findByPk(id);
 
-        if(!pix){
+        if (!pix) {
             return res.status(404).json({ mensagem: `PIX não encontrado` });
         }
 
-        return res.status(200).json(pix);
+        const pixResponse = await abacatePayService.selecionarPix(pix.id_integracao);
+
+        const integracao = {};
+
+        if (pixResponse.error) {
+            integracao.ok = false;
+            integracao.mensagem = 'Erro ao buscar dados do PIX na integração';
+        }
+
+        if (!pixResponse.error && !pixResponse.ok) {
+            integracao.ok = false;
+            integracao.mensagem = pixResponse.mensagem;
+        }
+
+        if (pixResponse.ok) {
+            integracao.ok = true;
+            if (pixResponse.data.status == 'PAID') {
+                integracao.mensagem = 'PIX pago';
+                pix.status = 'R';
+                pix.save();
+            } else {
+                integracao.menasgem = 'Dados PIX selecionados com sucesso';
+            }
+        }
+
+        return res.status(200).json({
+            ...pix.dataValues,
+            integracao
+        });
 
     } catch (error) {
         console.error(error);
@@ -88,4 +116,48 @@ const selecionar = async (req, res) => {
     }
 };
 
-export default { gerar, selecionar };
+const simularPagamento = async (req, res) => {
+    try {
+        if(!req.params.id) {
+            return res.status(400).json({ mensagem: 'Informe o ID do PIX' });
+        }
+        
+        const { id } = req.params;
+
+        if (!id) {
+            return res.status(400).json({ mensagem: 'Informe o ID do PIX' });
+        }
+
+        // Verificar se ID é número
+        if (isNaN(id)) {
+            return res.status(400).json({ mensagem: 'ID do PIX inválido' });
+        }
+
+        const pix = await PixModel.findByPk(id);
+
+        if (!pix) {
+            return res.status(404).json({ mensagem: 'PIX não encontrado' });
+        }
+
+        const pixResponse = await abacatePayService.simularPagamentoPix(pix.id_integracao);
+
+        if (pixResponse.error) {
+            throw new Error("Erro ao simular pagamento do PIX");
+        }
+
+        if (!pixResponse.ok) {
+            return res.status(400).json({ mensagem: pixResponse.mensagem });
+        }
+
+        pix.status = 'R'; // Simulando pagamento
+        await pix.save();
+
+        return res.status(200).json({ mensagem: 'Pagamento simulado com sucesso', pix });
+
+    } catch (error) {
+        console.error(error);
+        return res.status(500).json({ mensagem: 'Erro interno, contate o suporte' });
+    }
+}
+
+export default { gerar, selecionar, simularPagamento };

--- a/controllers/viewsController.js
+++ b/controllers/viewsController.js
@@ -1,0 +1,50 @@
+import Views from "../views/index.js";
+import banco from "../banco.js";
+
+const listar = async (req, res) => {
+    try {
+        const views = Object.keys(Views);
+
+        if(views.length === 0) {
+            return res.status(204).send();
+        }
+
+        return res.status(200).json(views);
+    } catch (error) {
+        console.error("Erro ao listar cobranças:", error);
+        res.status(500).json({ error: "Erro interno, contate o suporte" });
+    }
+};
+
+const listarDados = async (req, res) => {
+    const { view } = req.params;
+
+    if (!view || !Views[view]) {
+        return res.status(404).json({ error: "View não encontrada" });
+    }
+
+    try {
+        if(!req.params.view){
+            return res.status(400).json({ error: "Informe o nome da view" });
+        }
+
+        const { view } = req.params;
+
+        const dados = await Views[view].Model.findAll({
+            where: { id_beneficiario: req.beneficiario.id },
+            raw: true,
+        });
+        
+        if(dados.length === 0) {
+            return res.status(204).send();
+        }
+
+        return res.status(200).json(dados);
+
+    } catch (error) {
+        console.error("Erro ao selecionar view:", error);
+        res.status(500).json({ error: "Erro interno, contate o suporte" });
+    }
+};
+
+export default { listar, listarDados };

--- a/migrate.js
+++ b/migrate.js
@@ -1,8 +1,16 @@
 import banco from "./banco.js";
 import models from "./models/index.js";
+import views from "./views/index.js";
 
-console.log(models);
+// console.log(models);
 
+console.log("Criando tabelas...");
 await banco.sync({ alter: true});
 console.log("Tabelas criadas com sucesso");
 
+console.log('Criando views...');
+for (const view in views) {
+    await banco.query(`DROP TABLE IF EXISTS ${views[view].Model.getTableName()};`);
+    await banco.query(views[view].sql);
+}
+console.log('Views criadas com sucesso!');

--- a/models/pixModel.js
+++ b/models/pixModel.js
@@ -8,10 +8,6 @@ const PixModel = banco.define('pix', {
         primaryKey: true,
         autoIncrement: true
     },
-    pix_type: {
-        type: DataTypes.ENUM('cc','qr'),
-        allowNull: false,
-    },
     valor: {
         type: DataTypes.DECIMAL(10, 2),
         allowNull: false,
@@ -25,15 +21,14 @@ const PixModel = banco.define('pix', {
         allowNull: false,
         defaultValue: 'A'
     },
-    cod: {
-        type: DataTypes.STRING,
+    cod_copia_cola: {
+        type: DataTypes.TEXT,
         unique: true,
-        allowNull: true
+        allowNull: false
     },
-    qrcode_url: {
-        type: DataTypes.STRING,
-        unique: true,
-        allowNull: true
+    qrcode_base64: {
+        type: DataTypes.TEXT,
+        allowNull: false
     },
     id_beneficiario: {
         type: DataTypes.INTEGER,
@@ -44,10 +39,21 @@ const PixModel = banco.define('pix', {
         allowNull: false,
         defaultValue: DataTypes.NOW
     },
-    charge_id: {
+    id_integracao: {
         type: DataTypes.STRING,
         allowNull: false,
-        unique: true
+    },
+    cliente_nome: { 
+        type: DataTypes.STRING,
+        allowNull: false,
+    },
+    cliente_email: {
+        type: DataTypes.STRING,
+        allowNull: false,
+    },
+    cliente_cpf_cnpj: {
+        type: DataTypes.STRING,
+        allowNull: false
     },
 });
 
@@ -59,7 +65,5 @@ PixModel.associate = (models) => {
         }
     });
 };
-
-chargeIdGeradorHook(PixModel);
 
 export default PixModel;

--- a/routes/pixRoutes.js
+++ b/routes/pixRoutes.js
@@ -4,5 +4,6 @@ import pixController from '../controllers/pixController.js';
 const router = express.Router();
 
 router.post('/gerar', pixController.gerar);
+router.get('/:id', pixController.selecionar);
 
 export default router;

--- a/routes/pixRoutes.js
+++ b/routes/pixRoutes.js
@@ -1,0 +1,8 @@
+import express from 'express';
+import pixController from '../controllers/pixController.js';
+
+const router = express.Router();
+
+router.post('/gerar', pixController.gerar);
+
+export default router;

--- a/routes/pixRoutes.js
+++ b/routes/pixRoutes.js
@@ -5,5 +5,6 @@ const router = express.Router();
 
 router.post('/gerar', pixController.gerar);
 router.get('/:id', pixController.selecionar);
+router.post('/:id/simular-pagamento', pixController.simularPagamento);
 
 export default router;

--- a/routes/viewsRoutes.js
+++ b/routes/viewsRoutes.js
@@ -1,0 +1,9 @@
+import express from 'express';
+import viewsController from '../controllers/viewsController.js';
+
+const router = express.Router();
+
+router.get('/', viewsController.listar);
+router.get('/:view', viewsController.listarDados);
+
+export default router;

--- a/server.js
+++ b/server.js
@@ -15,6 +15,7 @@ import tokenApiRoutes from './routes/tokenApiRoutes.js';
 import cidadeRoutes from './routes/cidadeRoutes.js';
 import estadoRoutes from './routes/estadoRoutes.js';
 import pixRoutes from './routes/pixRoutes.js';
+import viewsRoutes from './routes/viewsRoutes.js'; // Importa as rotas de views
 
 // Configurando express app
 const app = express();
@@ -55,5 +56,7 @@ app.use('/token', tokenApiRoutes);
 app.use('/cidades', cidadeRoutes);
 app.use('/estados', estadoRoutes);
 app.use('/pix',pixRoutes);
+app.use('/views', viewsRoutes); // Adiciona as rotas de views
+
 
 app.listen(PORT, () => console.log(`Servidor rodando na porta ${PORT}`));

--- a/server.js
+++ b/server.js
@@ -14,6 +14,7 @@ import beneficiarioRoutes from "./routes/beneficiarioRoutes.js";
 import tokenApiRoutes from './routes/tokenApiRoutes.js';
 import cidadeRoutes from './routes/cidadeRoutes.js';
 import estadoRoutes from './routes/estadoRoutes.js';
+import pixRoutes from './routes/pixRoutes.js';
 
 // Configurando express app
 const app = express();
@@ -53,5 +54,6 @@ app.use("/beneficiarios", beneficiarioRoutes);
 app.use('/token', tokenApiRoutes);
 app.use('/cidades', cidadeRoutes);
 app.use('/estados', estadoRoutes);
+app.use('/pix',pixRoutes);
 
 app.listen(PORT, () => console.log(`Servidor rodando na porta ${PORT}`));

--- a/services/abacatePayService.js
+++ b/services/abacatePayService.js
@@ -1,0 +1,93 @@
+// Importando bibliotecas
+import dotenv from 'dotenv';
+
+// Importando utilitários
+import { erroPersonalizado } from '../utils/erros.js';
+
+// Configurando bibliotecas
+dotenv.config();
+
+const apiUrl = `https://api.abacatepay.com/v1/pixQrCode/create`;
+const tempoExpiracaoPixSegundos = 3600; // 1 Hora
+
+const errosTraducao = {
+    'Invalid taxId': 'CPF/CNPJ inválido',
+};
+
+const gerarPix = async ({ valor_decimal, cliente_nome, cliente_email, cliente_cpf_cnpj, cliente_telefone = '' }) => {
+
+    try {
+        // Checar se valor é do tipo decimal (0.00), se sim, criar valor_centavos, pois a API só permite centavos
+        const valorConvertido = Number(valor_decimal);
+        if (!Number.isFinite(valorConvertido) || valorConvertido < 0) {
+            throw erroPersonalizado('Valor deve ser decimal: 0.00', 'VALIDACAO');
+        }
+
+        // Checar se e-mail informado é válido
+        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        if (!emailRegex.test(cliente_email)) {
+            throw erroPersonalizado('E-mail inválido', 'VALIDACAO');
+        }
+
+        const valor_centavos = Math.round(valor_decimal * 100);
+
+        const bodyObj = {
+            amount: valor_centavos,
+            expiresIn: tempoExpiracaoPixSegundos,
+            customer: {
+                name: cliente_nome,
+                cellphone: cliente_telefone,
+                email: cliente_email,
+                taxId: cliente_cpf_cnpj
+            }
+        };
+
+        const options = {
+            method: 'POST',
+            headers: {
+                Authorization: `Bearer ${process.env.ABACATE_PAY_API_KEY}`,
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(bodyObj)
+        }
+
+        const responsePix = await fetch(apiUrl, options);
+        const dataPix = await responsePix.json();
+
+        if (!responsePix.ok) {
+            if (errosTraducao[data.error]) {
+                throw erroPersonalizado('CPF/CNPJ inválido', 'VALIDACAO');
+            } else {
+                console.log(data.error);
+                throw erroPersonalizado('Erro ao criar PIX na integração, contate o suporte', 'OUTRO');
+            }
+        }
+
+        return {
+            ok: true,
+            error: false,
+            data: dataPix.data,
+            mensagem: 'PIX gerado com sucesso'
+        }
+
+    } catch (error) {
+        console.log(error);
+        if (error.tipo) {
+            return {
+                ok: false,
+                error: false,
+                data: {},
+                mensagem: error.message
+            }
+        } else {
+            return {
+                ok: false,
+                error: true,
+                data: {},
+                mensagem: 'Erro interno, contate o suporte'
+            }
+        }
+    }
+};
+
+export default { gerarPix };

--- a/utils/erros.js
+++ b/utils/erros.js
@@ -1,0 +1,7 @@
+const erroPersonalizado = (mensagem, tipo) => {
+    const error = new Error(mensagem);
+    error.tipo = tipo;
+    return error;
+}
+
+export { erroPersonalizado };

--- a/views/cobrancasView.js
+++ b/views/cobrancasView.js
@@ -1,0 +1,94 @@
+import { DataTypes } from "sequelize";
+import banco from '../banco.js';
+
+const Model = banco.define('cobrancas_view', {
+    id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true
+    },
+    valor: {
+        type: DataTypes.DECIMAL(10, 2),
+        allowNull: false
+    },
+    status: {
+        type: DataTypes.STRING,
+        allowNull: false
+    },
+    data_cadastro: {
+        type: DataTypes.DATE,
+        allowNull: false
+    },
+    id_beneficiario: {
+        type: DataTypes.INTEGER,
+        allowNull: false
+    },
+    id_integracao: {
+        type: DataTypes.INTEGER,
+        allowNull: true
+    },
+    nosso_numero: {
+        type: DataTypes.STRING,
+        allowNull: true
+    },
+    token: {
+        type: DataTypes.STRING,
+        allowNull: true
+    },
+    tipo_cobranca: {
+        type: DataTypes.STRING,
+        allowNull: false
+    }
+});
+
+const sql = `
+    CREATE OR REPLACE VIEW cobrancas_view AS
+    (SELECT
+        p.id,
+        p.valor,
+        CASE p.status
+            WHEN 'A' THEN 'A receber'
+            WHEN 'R' THEN 'Recebido'
+            WHEN 'C' THEN 'Cancelado'
+        END AS status,
+    --	p.status::text AS status,
+        p.data_cadastro,
+        p.id_beneficiario,
+        p.id_integracao,
+        NULL AS nosso_numero,
+        NULL AS token,
+        'Pix' AS tipo_cobranca
+    FROM pix AS p)
+    UNION
+    (SELECT
+        b.id,
+        b.valor,
+        CASE b.status
+            WHEN 'A' THEN 'A receber'
+            WHEN 'R' THEN 'Recebido'
+            WHEN 'C' THEN 'Cancelado'
+        END AS status,
+        b.data_emissao AS data_cadastro,
+        b.id_beneficiario,
+        NULL AS id_integracao,
+        b.nosso_numero,
+        NULL AS TOKEN,
+        'Boleto' AS tipo_cobranca
+    FROM boleto AS b)
+    UNION
+    (SELECT
+        cc.id,
+        cc.valor,
+        CASE cc.status
+            WHEN 'A' THEN 'A receber'
+            WHEN 'R' THEN 'Recebido'
+            WHEN 'C' THEN 'Cancelado'
+        END AS status,
+        cc.data_cadastro,
+        cc.id_beneficiario,
+        NULL AS id_integracao,
+        NULL AS nosso_numero,
+        cc.token,
+        'Cartão' AS tipo_cobranca
+    FROM cobranca_cartao AS cc);`;
+
+export default { Model, sql };

--- a/views/index.js
+++ b/views/index.js
@@ -1,0 +1,8 @@
+// Views
+import cobrancasView from "./cobrancasView.js";
+
+const views = {
+  cobrancas: cobrancasView,
+};
+
+export default views;


### PR DESCRIPTION
Mudei alguns campos no banco de dados para se adaptar à integração de PIX que usamos: abacatepay

Ela gera um ID único próprio em formato de texto,
Ela também necessita de dados de cliente, vamos armazenar por razões de histórico
Mudei o nome de colunas de qrcode e pix copia e cola para ficar mais intuitivo.
Tirei índice unique de qrcode base 64 porque o texto guardado é muito grande e extrapola o tamanho máximo de índices do BD, eu poderia ter feito um hash, mas é muito trabalho